### PR TITLE
Update rce-engine version and dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Pull rce-images-python
         run: |
-          docker pull ghcr.io/toolkithub/rce-images-python:edge
+          docker pull toolkithub/python:edge
 
       - name: Setup docker environment
         run: |
@@ -39,7 +39,7 @@ jobs:
           output=$(curl -s -X POST \
             -H "X-Access-Token: ${{ secrets.RCE_ACCESS_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"image": "ghcr.io/toolkithub/rce-images-python:edge", "payload": {"language": "python", "files": [{"name": "main.py", "content": "print(42)"}]}}' \
+            -d '{"image": "toolkithub/python:edge", "payload": {"language": "python", "files": [{"name": "main.py", "content": "print(42)"}]}}' \
             http://localhost:50051/run
           )
 

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,12 +2,12 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.2
+  version: 1.22.3
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.1
+      ref: v1.6.2
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,7 +20,7 @@ runtimes:
 lint:
   enabled:
     - actionlint@1.7.1
-    - checkov@3.2.219
+    - checkov@3.2.234
     - clippy@1.65.0
     - git-diff-check
     - markdownlint@0.41.0
@@ -32,7 +32,7 @@ lint:
     - shfmt@3.6.0
     - taplo@0.9.3
     - trivy@0.54.1
-    - trufflehog@3.81.7
+    - trufflehog@3.81.9
     - yamllint@1.35.1
 actions:
   enabled:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "rce-engine"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "actix-web",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rce-engine"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Success Kingsley <hello@xosnrdev.tech>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# RCE Engine
+# rce-engine
 
 [![Build Test](https://github.com/ToolKitHub/rce-engine/actions/workflows/test.yml/badge.svg)](https://github.com/ToolKitHub/rce-engine/actions/workflows/test.yml)
+
+> An engine for running untrusted code inside transient docker containers.
 
 This service provides a http api for running untrusted code inside transient docker containers.
 For every run request a new container is started and deleted.
@@ -20,7 +22,7 @@ The communication with the docker daemon happens via it's api over the unix sock
 When a run request is posted to rce-engine it will create a new temporary container.
 The container is required to listen for a json payload on stdin and must write the
 run result to stdout as a json object containing the properties: stdout, stderr and error.
-The docker images used [here](https://github.com/orgs/ToolKitHub/packages).
+The docker images used [here](https://hub.docker.com/u/toolkithub).
 
 ## Performance
 
@@ -58,14 +60,18 @@ Depending on your use-case you should also consider to:
 - Drop [capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) using `DOCKER_CONTAINER_CAP_DROP`
 - Use the [gVisor](https://gvisor.dev/) runtime
 
-## Installation with `CLI` (Recommended)
+## How to install
+
+With CLI:
+
+> The following command will install rce-engine on a fresh Ubuntu 22.04 machine or latest.
 
 ```bash
     curl -fsSL https://raw.githubusercontent.com/toolkithub/rce-engine/main/scripts/install.sh -o install.sh
     sudo bash ./install.sh
 ```
 
-For more control over the installation and configuration:
+Manual installation:
 
 - [Run rce-engine with systemd](docs/install/ubuntu-22.04.md) (recommended)
 - [Run rce-engine in a docker container](docs/install/docker-ubuntu-22.04.md) (some people run into issues while running rce-engine in a container, see open issues)

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> { } }:
 pkgs.rustPlatform.buildRustPackage rec {
   pname = "rce-engine";
-  version = "1.2.1";
+  version = "1.2.2";
   cargoLock.lockFile = ./Cargo.lock;
   src = pkgs.lib.cleanSource ./.;
 }

--- a/docs/install/ubuntu-22.04.md
+++ b/docs/install/ubuntu-22.04.md
@@ -28,7 +28,7 @@ usermod -aG docker rce
 ```bash
 mkdir /home/rce/bin
 cd /home/rce/bin
-wget https://github.com/toolkithub/rce-engine/releases/download/v.1.2.1/rce-engine_linux-x64.tar.gz
+wget https://github.com/toolkithub/rce-engine/releases/download/v.1.2.2/rce-engine_linux-x64.tar.gz
 tar -zxf rce-engine_linux-x64.tar.gz
 rm rce-engine_linux-x64.tar.gz
 chown -R rce:rce /home/rce/bin

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@
 
 #+-------------------------------------------------------------------------------------------------------------------------------------+
 # Author: Success Kingsley <hello@xosnrdev.tech>
-# Last Updated: 2024-08-11
-# Version: 1.2.1
+# Last Updated: 2024-08-20
+# Version: 1.2.2
 # License: MIT
 # Description: This script installs the rce-engine on an Ubuntu 22.04 or latest machine.
 # Usage: curl -fsSL https://raw.githubusercontent.com/toolkithub/rce-engine/main/scripts/install.sh -o install.sh \
@@ -75,7 +75,7 @@ sudo mkdir -p /home/rce/bin
 cd /home/rce/bin
 
 log "Downloading rce-engine binary..."
-curl -LO https://github.com/toolkithub/rce-engine/releases/download/v1.2.1/rce-engine_linux-x64.tar.gz || error "Failed to download rce-engine binary"
+curl -LO https://github.com/toolkithub/rce-engine/releases/download/v1.2.2/rce-engine_linux-x64.tar.gz || error "Failed to download rce-engine binary"
 
 log "Extracting rce-engine binary..."
 sudo tar -zxf rce-engine_linux-x64.tar.gz || error "Failed to extract rce-engine binary"
@@ -172,7 +172,7 @@ trim_whitespace() {
 pull_language_image() {
 	local language=$1
 	log "Pulling image for ${language}..."
-	if ! docker pull ghcr.io/toolkithub/rce-images-$(convert_to_lowercase "${language}"):edge; then
+	if ! docker pull toolkithub/$(convert_to_lowercase "${language}"):edge; then
 		error "Failed to pull image for ${language}"
 		return 1
 	fi


### PR DESCRIPTION
This pull request updates the rce-engine version to 1.2.2 and updates the installation script and dependencies accordingly. The docker image references for rce-images-python and trunk plugins are also updated.