### PR TITLE
Quick Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rce-engine is a service that provides a HTTP API for running untrusted code insi
 Install rce-engine
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/toolkithub/rce-engine/main/scripts/installer.sh | bash
+curl -fsSLO --tlsv1.2 https://raw.githubusercontent.com/toolkithub/rce-engine/main/scripts/installer.sh && bash installer.sh
 ```
 
 Need more control? Check our [detailed installation guides](#installation-instructions).


### PR DESCRIPTION
This pr addresses an issue where the installer script fails with `sed: bash: No such file or directory` when piped directly into bash.